### PR TITLE
When attempting to login with an empty PIN, pass to pkcs11 as NULL

### DIFF
--- a/pkcs11.go
+++ b/pkcs11.go
@@ -207,6 +207,9 @@ CK_RV SetOperationState(struct ctx * c, CK_SESSION_HANDLE session,
 CK_RV Login(struct ctx *c, CK_SESSION_HANDLE session, CK_USER_TYPE userType,
 	    char *pin, CK_ULONG pinLen)
 {
+	if (pinLen == 0) {
+		pin = NULL;
+	}
 	CK_RV e =
 	    c->sym->C_Login(session, userType, (CK_UTF8CHAR_PTR) pin, pinLen);
 	return e;


### PR DESCRIPTION
Passing a PIN of NULL is used to indicate that, e.g., PIN
authentication happens outside of the pkcs11 process (through e.g. an
external PIN pad). Since the empty string is generally used as the
absence of a value in Go, convert that to NULL in C.

(I can't entirely discount the possibility that some random device
somewhere actually has a 0-length PIN, but it seems unlikely...)