### PR TITLE
Allow compilation with windows,linux,darwin

### DIFF
--- a/pkcs11.go
+++ b/pkcs11.go
@@ -11,6 +11,10 @@ package pkcs11
 // * CK_ULONG never overflows an Go int
 
 /*
+#cgo windows LDFLAGS: -Wl,--no-as-needed -lltdl
+#cgo linux LDFLAGS: -Wl,--no-as-needed -lltdl -ldl
+#cgo darwin CFLAGS: -I/usr/local/share/libtool
+#cgo darwin LDFLAGS: -lltdl -L/usr/local/lib/ -I/usr/local/share/libtool
 #cgo LDFLAGS: -lltdl
 #define CK_PTR *
 #ifndef NULL_PTR


### PR DESCRIPTION
Windows and linux require extra flags to avoid 'dlopen not found' and more compile errors.
Has been tested with `xgo` cross-compilation