### PR TITLE
Extent error check in GetMechanismList to allow a CKR_BUFFER_TOO_SMAL…

### DIFF
--- a/pkcs11.go
+++ b/pkcs11.go
@@ -115,6 +115,7 @@ CK_RV GetMechanismList(struct ctx * c, CK_ULONG slotID,
 {
 	CK_RV e =
 	    c->sym->C_GetMechanismList((CK_SLOT_ID) slotID, NULL, mechlen);
+	// Gemaltos PKCS11 implementation returns CKR_BUFFER_TOO_SMALL on a NULL ptr instad of CKR_OK as the spec states.    
 	if (e != CKR_OK && e != CKR_BUFFER_TOO_SMALL) {
 		return e;
 	}

--- a/pkcs11.go
+++ b/pkcs11.go
@@ -115,7 +115,7 @@ CK_RV GetMechanismList(struct ctx * c, CK_ULONG slotID,
 {
 	CK_RV e =
 	    c->sym->C_GetMechanismList((CK_SLOT_ID) slotID, NULL, mechlen);
-	if (e != CKR_OK) {
+	if (e != CKR_OK && e != CKR_BUFFER_TOO_SMALL) {
 		return e;
 	}
 	*mech = calloc(*mechlen, sizeof(CK_MECHANISM_TYPE));


### PR DESCRIPTION
…L result when passing a NULL pointer

This allow the lib to work with gemaltos pkcs11 library.
Fixes #30