### PR TITLE
Fix compilation on Windows amd64 (#24)

### DIFF
--- a/pkcs11.go
+++ b/pkcs11.go
@@ -778,7 +778,7 @@ func (c *Ctx) Destroy() {
 
 /* Initialize initializes the Cryptoki library. */
 func (c *Ctx) Initialize() error {
-	args := &C.CK_C_INITIALIZE_ARGS{nil, nil, nil, nil, C.CKF_OS_LOCKING_OK, nil}
+	args := &C.CK_C_INITIALIZE_ARGS{CreateMutex: nil, DestroyMutex: nil, LockMutex: nil, UnlockMutex: nil, flags: C.CKF_OS_LOCKING_OK, pReserved: nil}
 	e := C.Initialize(c.ctx, C.CK_VOID_PTR(args))
 	return toError(e)
 }


### PR DESCRIPTION
Apparently it is enough to specify the struct members names instead of passing them in order. As far as I can tell (with literally no experience in either C or Go programming), the problem has something to do with alignment of data inside the structs on 64 bit systems?

I apologize in advance for not testing this change (and also not really knowing what I'm doing). It compiles but I was not able to run the tests on a windows system due to the missing libsofthsm.