### PR TITLE
Fix structure alignment on windows

### DIFF
--- a/pkcs11.go
+++ b/pkcs11.go
@@ -11,6 +11,7 @@ package pkcs11
 // * CK_ULONG never overflows an Go int
 
 /*
+#cgo windows CFLAGS: -DREPACK_STRUCTURES
 #cgo windows LDFLAGS: -Wl,--no-as-needed -lltdl
 #cgo linux LDFLAGS: -Wl,--no-as-needed -lltdl -ldl
 #cgo darwin CFLAGS: -I/usr/local/share/libtool
@@ -18,17 +19,13 @@ package pkcs11
 #cgo openbsd CFLAGS: -I/usr/local/include/
 #cgo openbsd LDFLAGS: -lltdl -L/usr/local/lib/
 #cgo LDFLAGS: -lltdl
-#define CK_PTR *
-#define CK_DEFINE_FUNCTION(returnType, name) returnType name
-#define CK_DECLARE_FUNCTION(returnType, name) returnType name
-#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType (* name)
-#define CK_CALLBACK_FUNCTION(returnType, name) returnType (* name)
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <ltdl.h>
 #include <unistd.h>
-#include "pkcs11.h"
+#include "pkcs11go.h"
 
 struct ctx {
 	lt_dlhandle handle;
@@ -73,9 +70,12 @@ void Destroy(struct ctx *c)
 	free(c);
 }
 
-CK_RV Initialize(struct ctx * c, CK_VOID_PTR initArgs)
+CK_RV Initialize(struct ctx * c)
 {
-	return c->sym->C_Initialize(initArgs);
+	CK_C_INITIALIZE_ARGS args;
+	memset(&args, 0, sizeof(args));
+	args.flags = CKF_OS_LOCKING_OK;
+	return c->sym->C_Initialize(&args);
 }
 
 CK_RV Finalize(struct ctx * c)
@@ -83,9 +83,19 @@ CK_RV Finalize(struct ctx * c)
 	return c->sym->C_Finalize(NULL);
 }
 
-CK_RV GetInfo(struct ctx * c, CK_INFO_PTR info)
+CK_RV GetInfo(struct ctx * c, ckInfoPtr info)
 {
-	return c->sym->C_GetInfo(info);
+	CK_INFO p;
+	CK_RV e = c->sym->C_GetInfo(&p);
+	if (e != CKR_OK) {
+		return e;
+	}
+	info->cryptokiVersion = p.cryptokiVersion;
+	memcpy(info->manufacturerID, p.manufacturerID, sizeof(p.manufacturerID));
+	info->flags = p.flags;
+	memcpy(info->libraryDescription, p.libraryDescription, sizeof(p.libraryDescription));
+	info->libraryVersion = p.libraryVersion;
+	return e;
 }
 
 CK_RV GetSlotList(struct ctx * c, CK_BBOOL tokenPresent,
@@ -226,18 +236,22 @@ CK_RV Logout(struct ctx * c, CK_SESSION_HANDLE session)
 }
 
 CK_RV CreateObject(struct ctx * c, CK_SESSION_HANDLE session,
-		   CK_ATTRIBUTE_PTR temp, CK_ULONG tempCount,
+		   ckAttrPtr temp, CK_ULONG tempCount,
 		   CK_OBJECT_HANDLE_PTR obj)
 {
-	CK_RV e = c->sym->C_CreateObject(session, temp, tempCount, obj);
+	ATTR_TO_C(tempc, temp, tempCount, NULL);
+	CK_RV e = c->sym->C_CreateObject(session, tempc, tempCount, obj);
+	ATTR_FREE(tempc);
 	return e;
 }
 
 CK_RV CopyObject(struct ctx * c, CK_SESSION_HANDLE session, CK_OBJECT_HANDLE o,
-		 CK_ATTRIBUTE_PTR temp, CK_ULONG tempCount,
+		 ckAttrPtr temp, CK_ULONG tempCount,
 		 CK_OBJECT_HANDLE_PTR obj)
 {
-	CK_RV e = c->sym->C_CopyObject(session, o, temp, tempCount, obj);
+	ATTR_TO_C(tempc, temp, tempCount, NULL);
+	CK_RV e = c->sym->C_CopyObject(session, o, tempc, tempCount, obj);
+	ATTR_FREE(tempc);
 	return e;
 }
 
@@ -256,39 +270,47 @@ CK_RV GetObjectSize(struct ctx * c, CK_SESSION_HANDLE session,
 }
 
 CK_RV GetAttributeValue(struct ctx * c, CK_SESSION_HANDLE session,
-			CK_OBJECT_HANDLE object, CK_ATTRIBUTE_PTR temp,
+			CK_OBJECT_HANDLE object, ckAttrPtr temp,
 			CK_ULONG templen)
 {
+	ATTR_TO_C(tempc, temp, templen, NULL);
 	// Call for the first time, check the returned ulValue in the attributes, then
 	// allocate enough space and try again.
-	CK_RV e = c->sym->C_GetAttributeValue(session, object, temp, templen);
+	CK_RV e = c->sym->C_GetAttributeValue(session, object, tempc, templen);
 	if (e != CKR_OK) {
+		ATTR_FREE(tempc);
 		return e;
 	}
 	CK_ULONG i;
 	for (i = 0; i < templen; i++) {
-		if ((CK_LONG) temp[i].ulValueLen == -1) {
+		if ((CK_LONG) tempc[i].ulValueLen == -1) {
 			// either access denied or no such object
 			continue;
 		}
-		temp[i].pValue = calloc(temp[i].ulValueLen, sizeof(CK_BYTE));
+		tempc[i].pValue = calloc(tempc[i].ulValueLen, sizeof(CK_BYTE));
 	}
-	e = c->sym->C_GetAttributeValue(session, object, temp, templen);
+	e = c->sym->C_GetAttributeValue(session, object, tempc, templen);
+	ATTR_FROM_C(temp, tempc, templen);
+	ATTR_FREE(tempc);
 	return e;
 }
 
 CK_RV SetAttributeValue(struct ctx * c, CK_SESSION_HANDLE session,
-			CK_OBJECT_HANDLE object, CK_ATTRIBUTE_PTR temp,
+			CK_OBJECT_HANDLE object, ckAttrPtr temp,
 			CK_ULONG templen)
 {
-	CK_RV e = c->sym->C_SetAttributeValue(session, object, temp, templen);
+	ATTR_TO_C(tempc, temp, templen, NULL);
+	CK_RV e = c->sym->C_SetAttributeValue(session, object, tempc, templen);
+	ATTR_FREE(tempc);
 	return e;
 }
 
 CK_RV FindObjectsInit(struct ctx * c, CK_SESSION_HANDLE session,
-		      CK_ATTRIBUTE_PTR temp, CK_ULONG tempCount)
+		      ckAttrPtr temp, CK_ULONG tempCount)
 {
-	CK_RV e = c->sym->C_FindObjectsInit(session, temp, tempCount);
+	ATTR_TO_C(tempc, temp, tempCount, NULL);
+	CK_RV e = c->sym->C_FindObjectsInit(session, tempc, tempCount);
+	ATTR_FREE(tempc);
 	return e;
 }
 
@@ -308,9 +330,10 @@ CK_RV FindObjectsFinal(struct ctx * c, CK_SESSION_HANDLE session)
 }
 
 CK_RV EncryptInit(struct ctx * c, CK_SESSION_HANDLE session,
-		  CK_MECHANISM_PTR mechanism, CK_OBJECT_HANDLE key)
+		  ckMechPtr mechanism, CK_OBJECT_HANDLE key)
 {
-	CK_RV e = c->sym->C_EncryptInit(session, mechanism, key);
+	MECH_TO_C(m, mechanism);
+	CK_RV e = c->sym->C_EncryptInit(session, m, key);
 	return e;
 }
 
@@ -363,9 +386,10 @@ CK_RV EncryptFinal(struct ctx * c, CK_SESSION_HANDLE session,
 }
 
 CK_RV DecryptInit(struct ctx * c, CK_SESSION_HANDLE session,
-		  CK_MECHANISM_PTR mechanism, CK_OBJECT_HANDLE key)
+		  ckMechPtr mechanism, CK_OBJECT_HANDLE key)
 {
-	CK_RV e = c->sym->C_DecryptInit(session, mechanism, key);
+	MECH_TO_C(m, mechanism);
+	CK_RV e = c->sym->C_DecryptInit(session, m, key);
 	return e;
 }
 
@@ -418,9 +442,10 @@ CK_RV DecryptFinal(struct ctx * c, CK_SESSION_HANDLE session,
 }
 
 CK_RV DigestInit(struct ctx * c, CK_SESSION_HANDLE session,
-		 CK_MECHANISM_PTR mechanism)
+		 ckMechPtr mechanism)
 {
-	CK_RV e = c->sym->C_DigestInit(session, mechanism);
+	MECH_TO_C(m, mechanism);
+	CK_RV e = c->sym->C_DigestInit(session, m);
 	return e;
 }
 
@@ -468,9 +493,10 @@ CK_RV DigestFinal(struct ctx * c, CK_SESSION_HANDLE session, CK_BYTE_PTR * hash,
 }
 
 CK_RV SignInit(struct ctx * c, CK_SESSION_HANDLE session,
-	       CK_MECHANISM_PTR mechanism, CK_OBJECT_HANDLE key)
+	       ckMechPtr mechanism, CK_OBJECT_HANDLE key)
 {
-	CK_RV e = c->sym->C_SignInit(session, mechanism, key);
+	MECH_TO_C(m, mechanism);
+	CK_RV e = c->sym->C_SignInit(session, m, key);
 	return e;
 }
 
@@ -512,9 +538,10 @@ CK_RV SignFinal(struct ctx * c, CK_SESSION_HANDLE session, CK_BYTE_PTR * sig,
 }
 
 CK_RV SignRecoverInit(struct ctx * c, CK_SESSION_HANDLE session,
-		      CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE key)
+		      ckMechPtr mech, CK_OBJECT_HANDLE key)
 {
-	CK_RV rv = c->sym->C_SignRecoverInit(session, mech, key);
+	MECH_TO_C(m, mech);
+	CK_RV rv = c->sym->C_SignRecoverInit(session, m, key);
 	return rv;
 }
 
@@ -534,9 +561,10 @@ CK_RV SignRecover(struct ctx * c, CK_SESSION_HANDLE session, CK_BYTE_PTR data,
 }
 
 CK_RV VerifyInit(struct ctx * c, CK_SESSION_HANDLE session,
-		 CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE key)
+		 ckMechPtr mech, CK_OBJECT_HANDLE key)
 {
-	CK_RV rv = c->sym->C_VerifyInit(session, mech, key);
+	MECH_TO_C(m, mech);
+	CK_RV rv = c->sym->C_VerifyInit(session, m, key);
 	return rv;
 }
 
@@ -562,9 +590,10 @@ CK_RV VerifyFinal(struct ctx * c, CK_SESSION_HANDLE session, CK_BYTE_PTR sig,
 }
 
 CK_RV VerifyRecoverInit(struct ctx * c, CK_SESSION_HANDLE session,
-			CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE key)
+			ckMechPtr mech, CK_OBJECT_HANDLE key)
 {
-	CK_RV rv = c->sym->C_VerifyRecoverInit(session, mech, key);
+	MECH_TO_C(m, mech);
+	CK_RV rv = c->sym->C_VerifyRecoverInit(session, m, key);
 	return rv;
 }
 
@@ -657,33 +686,39 @@ CK_RV DecryptVerifyUpdate(struct ctx * c, CK_SESSION_HANDLE session,
 }
 
 CK_RV GenerateKey(struct ctx * c, CK_SESSION_HANDLE session,
-		  CK_MECHANISM_PTR mechanism, CK_ATTRIBUTE_PTR temp,
+		  ckMechPtr mechanism, ckAttrPtr temp,
 		  CK_ULONG tempCount, CK_OBJECT_HANDLE_PTR key)
 {
-	CK_RV e =
-	    c->sym->C_GenerateKey(session, mechanism, temp, tempCount, key);
+	MECH_TO_C(m, mechanism);
+	ATTR_TO_C(tempc, temp, tempCount, NULL);
+	CK_RV e = c->sym->C_GenerateKey(session, m, tempc, tempCount, key);
+	ATTR_FREE(tempc);
 	return e;
 }
 
 CK_RV GenerateKeyPair(struct ctx * c, CK_SESSION_HANDLE session,
-		      CK_MECHANISM_PTR mechanism, CK_ATTRIBUTE_PTR pub,
-		      CK_ULONG pubCount, CK_ATTRIBUTE_PTR priv,
+		      ckMechPtr mechanism, ckAttrPtr pub,
+		      CK_ULONG pubCount, ckAttrPtr priv,
 		      CK_ULONG privCount, CK_OBJECT_HANDLE_PTR pubkey,
 		      CK_OBJECT_HANDLE_PTR privkey)
 {
-	CK_RV e =
-	    c->sym->C_GenerateKeyPair(session, mechanism, pub, pubCount, priv,
-				      privCount,
-				      pubkey, privkey);
+	MECH_TO_C(m, mechanism);
+	ATTR_TO_C(pubc, pub, pubCount, NULL);
+	ATTR_TO_C(privc, priv, privCount, pubc);
+	CK_RV e = c->sym->C_GenerateKeyPair(session, m, pubc, pubCount,
+		privc, privCount, pubkey, privkey);
+	ATTR_FREE(pubc);
+	ATTR_FREE(privc);
 	return e;
 }
 
 CK_RV WrapKey(struct ctx * c, CK_SESSION_HANDLE session,
-	      CK_MECHANISM_PTR mechanism, CK_OBJECT_HANDLE wrappingkey,
+	      ckMechPtr mechanism, CK_OBJECT_HANDLE wrappingkey,
 	      CK_OBJECT_HANDLE key, CK_BYTE_PTR * wrapped,
 	      CK_ULONG_PTR wrappedlen)
 {
-	CK_RV rv = c->sym->C_WrapKey(session, mechanism, wrappingkey, key, NULL,
+	MECH_TO_C(m, mechanism);
+	CK_RV rv = c->sym->C_WrapKey(session, m, wrappingkey, key, NULL,
 				     wrappedlen);
 	if (rv != CKR_OK) {
 		return rv;
@@ -692,26 +727,32 @@ CK_RV WrapKey(struct ctx * c, CK_SESSION_HANDLE session,
 	if (*wrapped == NULL) {
 		return CKR_HOST_MEMORY;
 	}
-	rv = c->sym->C_WrapKey(session, mechanism, wrappingkey, key, *wrapped,
+	rv = c->sym->C_WrapKey(session, m, wrappingkey, key, *wrapped,
 			       wrappedlen);
 	return rv;
 }
 
 CK_RV DeriveKey(struct ctx * c, CK_SESSION_HANDLE session,
-		CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE basekey,
-		CK_ATTRIBUTE_PTR a, CK_ULONG alen, CK_OBJECT_HANDLE_PTR key)
+		ckMechPtr mech, CK_OBJECT_HANDLE basekey,
+		ckAttrPtr a, CK_ULONG alen, CK_OBJECT_HANDLE_PTR key)
 {
-	CK_RV e = c->sym->C_DeriveKey(session, mech, basekey, a, alen, key);
+	MECH_TO_C(m, mech);
+	ATTR_TO_C(tempc, a, alen, NULL);
+	CK_RV e = c->sym->C_DeriveKey(session, m, basekey, tempc, alen, key);
+	ATTR_FREE(tempc);
 	return e;
 }
 
 CK_RV UnwrapKey(struct ctx * c, CK_SESSION_HANDLE session,
-		CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE unwrappingkey,
+		ckMechPtr mech, CK_OBJECT_HANDLE unwrappingkey,
 		CK_BYTE_PTR wrappedkey, CK_ULONG wrappedkeylen,
-		CK_ATTRIBUTE_PTR a, CK_ULONG alen, CK_OBJECT_HANDLE_PTR key)
+		ckAttrPtr a, CK_ULONG alen, CK_OBJECT_HANDLE_PTR key)
 {
-	CK_RV e = c->sym->C_UnwrapKey(session, mech, unwrappingkey, wrappedkey,
-				      wrappedkeylen, a, alen, key);
+	MECH_TO_C(m, mech);
+	ATTR_TO_C(tempc, a, alen, NULL);
+	CK_RV e = c->sym->C_UnwrapKey(session, m, unwrappingkey, wrappedkey,
+				      wrappedkeylen, tempc, alen, key);
+	ATTR_FREE(tempc);
 	return e;
 }
 
@@ -739,6 +780,38 @@ CK_RV WaitForSlotEvent(struct ctx * c, CK_FLAGS flags, CK_ULONG_PTR slot)
 	    c->sym->C_WaitForSlotEvent(flags, (CK_SLOT_ID_PTR) slot, NULL);
 	return e;
 }
+
+#ifdef REPACK_STRUCTURES
+
+CK_RV attrsToC(CK_ATTRIBUTE_PTR *attrOut, ckAttrPtr attrIn, CK_ULONG count) {
+	CK_ATTRIBUTE_PTR attr = calloc(count, sizeof(CK_ATTRIBUTE));
+	if (attr == NULL) {
+		return CKR_HOST_MEMORY;
+	}
+	for (int i = 0; i < count; i++) {
+		attr[i].type = attrIn[i].type;
+		attr[i].pValue = attrIn[i].pValue;
+		attr[i].ulValueLen = attrIn[i].ulValueLen;
+	}
+	*attrOut = attr;
+	return CKR_OK;
+}
+
+void attrsFromC(ckAttrPtr attrOut, CK_ATTRIBUTE_PTR attrIn, CK_ULONG count) {
+	for (int i = 0; i < count; i++) {
+		attrOut[i].type = attrIn[i].type;
+		attrOut[i].pValue = attrIn[i].pValue;
+		attrOut[i].ulValueLen = attrIn[i].ulValueLen;
+	}
+}
+
+void mechToC(CK_MECHANISM_PTR mechOut, ckMechPtr mechIn) {
+	mechOut->mechanism = mechIn->mechanism;
+	mechOut->pParameter = mechIn->pParameter;
+	mechOut->ulParameterLen = mechIn->ulParameterLen;
+}
+
+#endif
 */
 import "C"
 import "strings"
@@ -778,8 +851,7 @@ func (c *Ctx) Destroy() {
 
 /* Initialize initializes the Cryptoki library. */
 func (c *Ctx) Initialize() error {
-	args := &C.CK_C_INITIALIZE_ARGS{CreateMutex: nil, DestroyMutex: nil, LockMutex: nil, UnlockMutex: nil, flags: C.CKF_OS_LOCKING_OK, pReserved: nil}
-	e := C.Initialize(c.ctx, C.CK_VOID_PTR(args))
+	e := C.Initialize(c.ctx)
 	return toError(e)
 }
 
@@ -794,8 +866,8 @@ func (c *Ctx) Finalize() error {
 
 /* GetInfo returns general information about Cryptoki. */
 func (c *Ctx) GetInfo() (Info, error) {
-	var p C.CK_INFO
-	e := C.GetInfo(c.ctx, C.CK_INFO_PTR(&p))
+	var p C.ckInfo
+	e := C.GetInfo(c.ctx, &p)
 	i := Info{
 		CryptokiVersion:    toVersion(p.cryptokiVersion),
 		ManufacturerID:     strings.TrimRight(string(C.GoBytes(unsafe.Pointer(&p.manufacturerID[0]), 32)), " "),
@@ -1050,11 +1122,11 @@ func (c *Ctx) GetObjectSize(sh SessionHandle, oh ObjectHandle) (uint, error) {
 func (c *Ctx) GetAttributeValue(sh SessionHandle, o ObjectHandle, a []*Attribute) ([]*Attribute, error) {
 	// copy the attribute list and make all the values nil, so that
 	// the C function can (allocate) fill them in
-	pa := make([]C.CK_ATTRIBUTE, len(a))
+	pa := make([]C.ckAttr, len(a))
 	for i := 0; i < len(a); i++ {
 		pa[i]._type = C.CK_ATTRIBUTE_TYPE(a[i].Type)
 	}
-	e := C.GetAttributeValue(c.ctx, C.CK_SESSION_HANDLE(sh), C.CK_OBJECT_HANDLE(o), C.CK_ATTRIBUTE_PTR(&pa[0]), C.CK_ULONG(len(a)))
+	e := C.GetAttributeValue(c.ctx, C.CK_SESSION_HANDLE(sh), C.CK_OBJECT_HANDLE(o), C.ckAttrPtr(&pa[0]), C.CK_ULONG(len(a)))
 	if toError(e) != nil {
 		return nil, toError(e)
 	}

--- a/pkcs11go.h
+++ b/pkcs11go.h
@@ -1,0 +1,83 @@
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+#define CK_PTR *
+#ifndef NULL_PTR
+#define NULL_PTR 0
+#endif
+#define CK_DEFINE_FUNCTION(returnType, name) returnType name
+#define CK_DECLARE_FUNCTION(returnType, name) returnType name
+#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType (* name)
+#define CK_CALLBACK_FUNCTION(returnType, name) returnType (* name)
+
+#include <unistd.h>
+#ifdef REPACK_STRUCTURES
+# pragma pack(push, 1)
+# include "pkcs11.h"
+# pragma pack(pop)
+#else
+# include "pkcs11.h"
+#endif
+
+#ifdef REPACK_STRUCTURES
+
+// Go doesn't support structures with non-default packing, but PKCS#11 requires
+// pack(1) on Windows. Use structures with the same members as the CK_ ones but
+// default packing, and copy data between the two.
+
+typedef struct ckInfo {
+	CK_VERSION cryptokiVersion;
+	CK_UTF8CHAR manufacturerID[32];
+	CK_FLAGS flags;
+	CK_UTF8CHAR libraryDescription[32];
+	CK_VERSION libraryVersion;
+} ckInfo, *ckInfoPtr;
+
+typedef struct ckAttr {
+	CK_ATTRIBUTE_TYPE type;
+	CK_VOID_PTR pValue;
+	CK_ULONG ulValueLen;
+} ckAttr, *ckAttrPtr;
+
+typedef struct ckMech {
+	CK_MECHANISM_TYPE mechanism;
+	CK_VOID_PTR pParameter;
+	CK_ULONG ulParameterLen;
+} ckMech, *ckMechPtr;
+
+CK_RV attrsToC(CK_ATTRIBUTE_PTR *attrOut, ckAttrPtr attrIn, CK_ULONG count);
+void attrsFromC(ckAttrPtr attrOut, CK_ATTRIBUTE_PTR attrIn, CK_ULONG count);
+void mechToC(CK_MECHANISM_PTR mechOut, ckMechPtr mechIn);
+
+#define ATTR_TO_C(aout, ain, count, other) \
+	CK_ATTRIBUTE_PTR aout; \
+	{ \
+		CK_RV e = attrsToC(&aout, ain, count); \
+		if (e != CKR_OK ) { \
+			if (other != NULL) free(other); \
+			return e; \
+		} \
+	}
+#define ATTR_FREE(aout) free(aout)
+#define ATTR_FROM_C(aout, ain, count) attrsFromC(aout, ain, count)
+#define MECH_TO_C(mout, min) \
+	CK_MECHANISM mval, *mout = &mval; \
+	if (min != NULL) { mechToC(mout, min); \
+	} else { mout = NULL; }
+
+#else // REPACK_STRUCTURES
+
+// Dummy types and macros to avoid any unnecessary copying on UNIX
+
+typedef CK_INFO ckInfo, *ckInfoPtr;
+typedef CK_ATTRIBUTE ckAttr, *ckAttrPtr;
+typedef CK_MECHANISM ckMech, *ckMechPtr;
+
+#define ATTR_TO_C(aout, ain, count, other) CK_ATTRIBUTE_PTR aout = ain
+#define ATTR_FREE(aout)
+#define ATTR_FROM_C(aout, ain, count)
+#define MECH_TO_C(mout, min) CK_MECHANISM_PTR mout = min
+
+#endif // REPACK_STRUCTURES

--- a/types.go
+++ b/types.go
@@ -5,18 +5,9 @@
 package pkcs11
 
 /*
-#define CK_PTR *
-#ifndef NULL_PTR
-#define NULL_PTR 0
-#endif
-#define CK_DEFINE_FUNCTION(returnType, name) returnType name
-#define CK_DECLARE_FUNCTION(returnType, name) returnType name
-#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType (* name)
-#define CK_CALLBACK_FUNCTION(returnType, name) returnType (* name)
-
 #include <stdlib.h>
 #include <string.h>
-#include "pkcs11.h"
+#include "pkcs11go.h"
 
 CK_ULONG Index(CK_ULONG_PTR array, CK_ULONG i)
 {
@@ -196,12 +187,12 @@ func NewAttribute(typ uint, x interface{}) *Attribute {
 }
 
 // cAttribute returns the start address and the length of an attribute list.
-func cAttributeList(a []*Attribute) (arena, C.CK_ATTRIBUTE_PTR, C.CK_ULONG) {
+func cAttributeList(a []*Attribute) (arena, C.ckAttrPtr, C.CK_ULONG) {
 	var arena arena
 	if len(a) == 0 {
 		return nil, nil, 0
 	}
-	pa := make([]C.CK_ATTRIBUTE, len(a))
+	pa := make([]C.ckAttr, len(a))
 	for i := 0; i < len(a); i++ {
 		pa[i]._type = C.CK_ATTRIBUTE_TYPE(a[i].Type)
 		//skip attribute if length is 0 to prevent panic in arena.Allocate
@@ -211,7 +202,7 @@ func cAttributeList(a []*Attribute) (arena, C.CK_ATTRIBUTE_PTR, C.CK_ULONG) {
 
 		pa[i].pValue, pa[i].ulValueLen = arena.Allocate(a[i].Value)
 	}
-	return arena, C.CK_ATTRIBUTE_PTR(&pa[0]), C.CK_ULONG(len(a))
+	return arena, C.ckAttrPtr(&pa[0]), C.CK_ULONG(len(a))
 }
 
 func cDate(t time.Time) []byte {
@@ -245,12 +236,12 @@ func NewMechanism(mech uint, x interface{}) *Mechanism {
 	return m
 }
 
-func cMechanismList(m []*Mechanism) (arena, C.CK_MECHANISM_PTR, C.CK_ULONG) {
+func cMechanismList(m []*Mechanism) (arena, C.ckMechPtr, C.CK_ULONG) {
 	var arena arena
 	if len(m) == 0 {
 		return nil, nil, 0
 	}
-	pm := make([]C.CK_MECHANISM, len(m))
+	pm := make([]C.ckMech, len(m))
 	for i := 0; i < len(m); i++ {
 		pm[i].mechanism = C.CK_MECHANISM_TYPE(m[i].Mechanism)
 		//skip parameter if length is 0 to prevent panic in arena.Allocate
@@ -260,7 +251,7 @@ func cMechanismList(m []*Mechanism) (arena, C.CK_MECHANISM_PTR, C.CK_ULONG) {
 
 		pm[i].pParameter, pm[i].ulParameterLen = arena.Allocate(m[i].Parameter)
 	}
-	return arena, C.CK_MECHANISM_PTR(&pm[0]), C.CK_ULONG(len(m))
+	return arena, C.ckMechPtr(&pm[0]), C.CK_ULONG(len(m))
 }
 
 // MechanismInfo provides information about a particular mechanism.


### PR DESCRIPTION
On Windows platforms PKCS#11 requires that all structures be packed
without padding. This would be easy to fix except that cgo apparently cannot interwork with packed structures... so all of the data has to be copied in and out of the structs from C.

Packing requirements are undefined for UNIX platforms which in practice
means leaving the compiler default. I've tried to leave the generated code the same as before for non-Windows targets.

I see other people have been contributing Windows issues/PRs, but I'm curious if they've been having success without fixing the alignment problem. I was getting segfaults and hangs because the pointers in the CK_FUNCTION_LIST were being misinterpreted as either different functions or totally bogus addresses.