### PR TITLE
Remove --no-as-needed from CGo flags

### DIFF
--- a/pkcs11.go
+++ b/pkcs11.go
@@ -12,8 +12,8 @@ package pkcs11
 
 /*
 #cgo windows CFLAGS: -DREPACK_STRUCTURES
-#cgo windows LDFLAGS: -Wl,--no-as-needed -lltdl
-#cgo linux LDFLAGS: -Wl,--no-as-needed -lltdl -ldl
+#cgo windows LDFLAGS: -lltdl
+#cgo linux LDFLAGS: -lltdl -ldl
 #cgo darwin CFLAGS: -I/usr/local/share/libtool
 #cgo darwin LDFLAGS: -lltdl -L/usr/local/lib/
 #cgo openbsd CFLAGS: -I/usr/local/include/


### PR DESCRIPTION
The `--no-as-needed` flag is the default so does not affect compilation.
Go 1.9.4 at least does not like additional cgo flags without extra options.

Fixes Windows and Linux builds.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>