### PR TITLE
Add support for CK_GCM_PARAMS

### DIFF
--- a/params.go
+++ b/params.go
@@ -32,7 +32,7 @@ func NewGCMParams(iv, aad []byte, tagSize int) *GCMParams {
 
 func cGCMParams(p *GCMParams) (arena, []byte) {
 	params := C.CK_GCM_PARAMS{
-		ulTagBits: C.CK_ULONG(p.TagSize * 8),
+		ulTagBits: C.CK_ULONG(p.TagSize),
 	}
 	var arena arena
 	if len(p.IV) > 0 {

--- a/params.go
+++ b/params.go
@@ -1,0 +1,49 @@
+// Copyright 2013 Miek Gieben. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs11
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include "pkcs11go.h"
+*/
+import "C"
+import "unsafe"
+
+// GCMParams represents the parameters for the AES-GCM mechanism.
+type GCMParams struct {
+	IV      []byte
+	AAD     []byte
+	TagSize int
+}
+
+// NewGCMParams returns a pointer to the AES-GCM parameters.
+// This is a convenience function for passing GCM parameters to
+// available mechanisms
+func NewGCMParams(iv, aad []byte, tagSize int) *GCMParams {
+	return &GCMParams{
+		IV:      iv,
+		AAD:     aad,
+		TagSize: tagSize,
+	}
+}
+
+func cGCMParams(p *GCMParams) (arena, []byte) {
+	params := C.CK_GCM_PARAMS{
+		ulTagBits: C.CK_ULONG(p.TagSize * 8),
+	}
+	var arena arena
+	if len(p.IV) > 0 {
+		iv, ivLen := arena.Allocate(p.IV)
+		params.pIv = C.CK_BYTE_PTR(iv)
+		params.ulIvLen = ivLen
+	}
+	if len(p.AAD) > 0 {
+		aad, aadLen := arena.Allocate(p.AAD)
+		params.pAAD = C.CK_BYTE_PTR(aad)
+		params.ulAADLen = aadLen
+	}
+	return arena, C.GoBytes(unsafe.Pointer(&params), C.int(unsafe.Sizeof(params)))
+}

--- a/types.go
+++ b/types.go
@@ -267,39 +267,3 @@ type MechanismInfo struct {
 	MaxKeySize uint
 	Flags      uint
 }
-
-// GCMParams represents the mechanism parameters for AES-GCM.
-type GCMParams struct {
-	IV      []byte
-	AAD     []byte
-	TagSize int
-}
-
-// NewGCMParams returns a pointer to the AES-GCM parameters.
-// This is a convenience function for passing GCM parameters to
-// available mechanisms
-func NewGCMParams(iv, aad []byte, tagSize int) *GCMParams {
-	return &GCMParams{
-		IV:      iv,
-		AAD:     aad,
-		TagSize: tagSize,
-	}
-}
-
-func cGCMParams(p *GCMParams) (arena, []byte) {
-	params := C.CK_GCM_PARAMS{
-		ulTagBits: C.CK_ULONG(p.TagSize * 8),
-	}
-	var arena arena
-	if len(p.IV) > 0 {
-		iv, ivLen := arena.Allocate(p.IV)
-		params.pIv = C.CK_BYTE_PTR(iv)
-		params.ulIvLen = ivLen
-	}
-	if len(p.AAD) > 0 {
-		aad, aadLen := arena.Allocate(p.AAD)
-		params.pAAD = C.CK_BYTE_PTR(aad)
-		params.ulAADLen = aadLen
-	}
-	return arena, C.GoBytes(unsafe.Pointer(&params), C.int(unsafe.Sizeof(params)))
-}

--- a/types.go
+++ b/types.go
@@ -151,7 +151,7 @@ type Attribute struct {
 }
 
 // NewAttribute allocates a Attribute and returns a pointer to it.
-// Note that this is merely a convience function, as values returned
+// Note that this is merely a convenience function, as values returned
 // from the HSM are not converted back to Go values, those are just raw
 // byte slices.
 func NewAttribute(typ uint, x interface{}) *Attribute {
@@ -221,6 +221,7 @@ func cDate(t time.Time) []byte {
 type Mechanism struct {
 	Mechanism uint
 	Parameter []byte
+	arena     arena
 }
 
 // NewMechanism returns a pointer to an initialized Mechanism.
@@ -231,8 +232,12 @@ func NewMechanism(mech uint, x interface{}) *Mechanism {
 		return m
 	}
 
-	// Add any parameters passed (For now presume always bytes were passed in, is there another case?)
-	m.Parameter = x.([]byte)
+	switch x.(type) {
+	case *GCMParams:
+		m.arena, m.Parameter = cGCMParams(x.(*GCMParams))
+	default:
+		m.Parameter = x.([]byte)
+	}
 
 	return m
 }
@@ -251,6 +256,7 @@ func cMechanismList(m []*Mechanism) (arena, C.ckMechPtr, C.CK_ULONG) {
 		}
 
 		pm[i].pParameter, pm[i].ulParameterLen = arena.Allocate(m[i].Parameter)
+		arena = append(arena, m[i].arena...)
 	}
 	return arena, C.ckMechPtr(&pm[0]), C.CK_ULONG(len(m))
 }
@@ -260,4 +266,40 @@ type MechanismInfo struct {
 	MinKeySize uint
 	MaxKeySize uint
 	Flags      uint
+}
+
+// GCMParams represents the mechanism parameters for AES-GCM.
+type GCMParams struct {
+	IV      []byte
+	AAD     []byte
+	TagSize int
+}
+
+// NewGCMParams returns a pointer to the AES-GCM parameters.
+// This is a convenience function for passing GCM parameters to
+// available mechanisms
+func NewGCMParams(iv, aad []byte, tagSize int) *GCMParams {
+	return &GCMParams{
+		IV:      iv,
+		AAD:     aad,
+		TagSize: tagSize,
+	}
+}
+
+func cGCMParams(p *GCMParams) (arena, []byte) {
+	params := C.CK_GCM_PARAMS{
+		ulTagBits: C.CK_ULONG(p.TagSize * 8),
+	}
+	var arena arena
+	if len(p.IV) > 0 {
+		iv, ivLen := arena.Allocate(p.IV)
+		params.pIv = C.CK_BYTE_PTR(iv)
+		params.ulIvLen = ivLen
+	}
+	if len(p.AAD) > 0 {
+		aad, aadLen := arena.Allocate(p.AAD)
+		params.pAAD = C.CK_BYTE_PTR(aad)
+		params.ulAADLen = aadLen
+	}
+	return arena, C.GoBytes(unsafe.Pointer(&params), C.int(unsafe.Sizeof(params)))
 }


### PR DESCRIPTION
This adds native support for CK_GCM_PARAM for the AES-GCM mechanism.  This makes it more convenient to pass the parameters to the CKM_AES_GCM mechanism.  

Example usage:
```go
NewMechanism(CKM_AES_GCM, NewGCMParams(iv, aad, 128))
```