### PR TITLE
Modifies the newly-added GCMParams to allow reading IV

### DIFF
--- a/params.go
+++ b/params.go
@@ -14,36 +14,64 @@ import "unsafe"
 
 // GCMParams represents the parameters for the AES-GCM mechanism.
 type GCMParams struct {
-	IV      []byte
-	AAD     []byte
-	TagSize int
+	arena
+	params  *C.CK_GCM_PARAMS
+	iv      []byte
+	aad     []byte
+	tagSize int
 }
 
-// NewGCMParams returns a pointer to the AES-GCM parameters.
+// NewGCMParams returns a pointer to AES-GCM parameters.
 // This is a convenience function for passing GCM parameters to
-// available mechanisms
+// available mechanisms.
+//
+// *NOTE*
+// Some HSMs, like CloudHSM, will ignore the IV you pass in and write their
+// own. As a result, to support all libraries, memory is not freed
+// automatically, so that after the EncryptInit/Encrypt operation the HSM's IV
+// can be read back out. It is up to the caller to ensure that Free() is called
+// on the GCMParams object at an appropriate time.
 func NewGCMParams(iv, aad []byte, tagSize int) *GCMParams {
 	return &GCMParams{
-		IV:      iv,
-		AAD:     aad,
-		TagSize: tagSize,
+		iv:      iv,
+		aad:     aad,
+		tagSize: tagSize,
 	}
 }
 
-func cGCMParams(p *GCMParams) (arena, []byte) {
+func cGCMParams(p *GCMParams) []byte {
 	params := C.CK_GCM_PARAMS{
-		ulTagBits: C.CK_ULONG(p.TagSize),
+		ulTagBits: C.CK_ULONG(p.tagSize),
 	}
 	var arena arena
-	if len(p.IV) > 0 {
-		iv, ivLen := arena.Allocate(p.IV)
+	if len(p.iv) > 0 {
+		iv, ivLen := arena.Allocate(p.iv)
 		params.pIv = C.CK_BYTE_PTR(iv)
 		params.ulIvLen = ivLen
 	}
-	if len(p.AAD) > 0 {
-		aad, aadLen := arena.Allocate(p.AAD)
+	if len(p.aad) > 0 {
+		aad, aadLen := arena.Allocate(p.aad)
 		params.pAAD = C.CK_BYTE_PTR(aad)
 		params.ulAADLen = aadLen
 	}
-	return arena, C.GoBytes(unsafe.Pointer(&params), C.int(unsafe.Sizeof(params)))
+	p.arena = arena
+	p.params = &params
+	return C.GoBytes(unsafe.Pointer(&params), C.int(unsafe.Sizeof(params)))
+}
+
+func (p *GCMParams) IV() []byte {
+	if p == nil || p.params == nil {
+		return nil
+	}
+	newIv := C.GoBytes(unsafe.Pointer(p.params.pIv), C.int(p.params.ulIvLen))
+	iv := make([]byte, len(newIv))
+	copy(iv, newIv)
+	return iv
+}
+
+func (p *GCMParams) Free() {
+	if p == nil || p.arena == nil {
+		return
+	}
+	p.arena.Free()
 }

--- a/params.go
+++ b/params.go
@@ -30,7 +30,14 @@ type GCMParams struct {
 // own. As a result, to support all libraries, memory is not freed
 // automatically, so that after the EncryptInit/Encrypt operation the HSM's IV
 // can be read back out. It is up to the caller to ensure that Free() is called
-// on the GCMParams object at an appropriate time.
+// on the GCMParams object at an appropriate time, which is after
+// Encrypt/Decrypt. As an example:
+//
+// gcmParams := pkcs11.NewGCMParams(make([]byte, 12), nil, 128)
+// p.ctx.EncryptInit(session, []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_AES_GCM, gcmParams)}, aesObjHandle)
+// ct, _ := p.ctx.Encrypt(session, pt)
+// iv := gcmParams.IV()
+// gcmParams.Free()
 func NewGCMParams(iv, aad []byte, tagSize int) *GCMParams {
 	return &GCMParams{
 		iv:      iv,
@@ -74,4 +81,6 @@ func (p *GCMParams) Free() {
 		return
 	}
 	p.arena.Free()
+	p.params = nil
+	p.arena = nil
 }

--- a/types.go
+++ b/types.go
@@ -221,7 +221,6 @@ func cDate(t time.Time) []byte {
 type Mechanism struct {
 	Mechanism uint
 	Parameter []byte
-	arena     arena
 }
 
 // NewMechanism returns a pointer to an initialized Mechanism.
@@ -234,7 +233,7 @@ func NewMechanism(mech uint, x interface{}) *Mechanism {
 
 	switch x.(type) {
 	case *GCMParams:
-		m.arena, m.Parameter = cGCMParams(x.(*GCMParams))
+		m.Parameter = cGCMParams(x.(*GCMParams))
 	default:
 		m.Parameter = x.([]byte)
 	}
@@ -256,7 +255,6 @@ func cMechanismList(m []*Mechanism) (arena, C.ckMechPtr, C.CK_ULONG) {
 		}
 
 		pm[i].pParameter, pm[i].ulParameterLen = arena.Allocate(m[i].Parameter)
-		arena = append(arena, m[i].arena...)
 	}
 	return arena, C.ckMechPtr(&pm[0]), C.CK_ULONG(len(m))
 }


### PR DESCRIPTION
After submitting #71 we found this little snippet from Amazon's CloudHSM
documentation:

```
Note

When performing AES-GCM encryption, the HSM ignores the initialization
vector (IV) in the request and uses an IV that it generates. The HSM
writes the generated IV to the memory reference pointed to by the pIV
element of the CK_GCM_PARAMS parameters structure that you supply.
```

This isn't, so far as we can tell, a requirement of the v2.4 standard,
but CloudHSM is already used quite a lot and that will only grow.

This changes the structure to allow pulling out the IV after an encrypt
operation, but with the caveat that manual freeing is necessary. We
didn't see a better way of handling this without significantly changing
the API of the actual PKCS11 calls as they're mapped into the library.
This does make an assumption that no library will free this memory for
you during its handling of the Encrypt call, but that would be behavior
at odds with how all other structures are handled, where the client code
performs the free.

The other way it might be handled would be to add EncryptInitGCM and
EncryptGCM but it feels more intrusive to create special purpose calls
for individual ciphers.