### PR TITLE
Deprecate use of boolean return value from FindObjects (#26)

### DIFF
--- a/pkcs11.go
+++ b/pkcs11.go
@@ -1164,8 +1164,10 @@ func (c *Ctx) FindObjectsInit(sh SessionHandle, temp []*Attribute) error {
 
 // FindObjects continues a search for token and session
 // objects that match a template, obtaining additional object
-// handles. The returned boolean indicates if the list would
-// have been larger than max.
+// handles. Calling the function repeatedly may yield additional results until
+// an empty slice is returned.
+//
+// The returned boolean value is deprecated and should be ignored.
 func (c *Ctx) FindObjects(sh SessionHandle, max int) ([]ObjectHandle, bool, error) {
 	var (
 		objectList C.CK_OBJECT_HANDLE_PTR

--- a/pkcs11_test.go
+++ b/pkcs11_test.go
@@ -123,9 +123,9 @@ func TestFindObject(t *testing.T) {
 	if e := p.FindObjectsInit(session, template); e != nil {
 		t.Fatalf("failed to init: %s\n", e)
 	}
-	obj, b, e := p.FindObjects(session, 2)
+	obj, _, e := p.FindObjects(session, 2)
 	if e != nil {
-		t.Fatalf("failed to find: %s %v\n", e, b)
+		t.Fatalf("failed to find: %s\n", e)
 	}
 	if e := p.FindObjectsFinal(session); e != nil {
 		t.Fatalf("failed to finalize: %s\n", e)


### PR DESCRIPTION
The previous behavior is not consistent with the specification; the only
way to detect the end of the search is when no objects are returned. In
the future this field should be removed but in the meantime there is no
need to force a breaking change.

Also updates p11.Session.FindObjects to no longer use the deprecated
field, and to handle arbitrarily large result sets.