### PR TITLE
Add ECDH1 derive params

### DIFF
--- a/const.go
+++ b/const.go
@@ -720,4 +720,6 @@ const (
 	CKF_EXCLUDE_CHALLENGE                = 0x00000008
 	CKF_EXCLUDE_PIN                      = 0x00000010
 	CKF_USER_FRIENDLY_OTP                = 0x00000020
+	CKD_NULL                             = 0x00000001
+	CKD_SHA1_KDF                         = 0x00000002
 )

--- a/types.go
+++ b/types.go
@@ -243,13 +243,13 @@ func NewMechanism(mech uint, x interface{}) *Mechanism {
 	}
 
 	switch p := x.(type) {
-	case *GCMParams, *OAEPParams:
+	case *GCMParams, *OAEPParams, *ECDH1DeriveParams:
 		// contains pointers; defer serialization until cMechanism
 		m.generator = p
 	case []byte:
 		m.Parameter = p
 	default:
-		panic("parameter must be one of type: []byte, *GCMParams, *OAEPParams")
+		panic("parameter must be one of type: []byte, *GCMParams, *OAEPParams, *ECDH1DeriveParams")
 	}
 
 	return m
@@ -270,6 +270,8 @@ func cMechanism(mechList []*Mechanism) (arena, *C.CK_MECHANISM) {
 		param = cGCMParams(p)
 	case *OAEPParams:
 		param, arena = cOAEPParams(p, arena)
+	case *ECDH1DeriveParams:
+		param, arena = cECDH1DeriveParams(p, arena)
 	}
 	if len(param) != 0 {
 		buf, len := arena.Allocate(param)


### PR DESCRIPTION
This PR fixes this issue: https://github.com/miekg/pkcs11/issues/53

- Add struct for CK_ECDH1_DERIVE_PARAMS for use with the CKM_ECDH1_DERIVE mechanism.
- Add KDF constants.
- Support ECDH1DeriveParams in NewMechanism.