### PR TITLE
[p11] Return error in Session.FindObject; typo fix.

### DIFF
--- a/p11/session.go
+++ b/p11/session.go
@@ -57,7 +57,7 @@ type sessionImpl struct {
 func (s *sessionImpl) FindObject(template []*pkcs11.Attribute) (Object, error) {
 	objects, err := s.FindObjects(template)
 	if err != nil {
-		return Object{}, nil
+		return Object{}, err
 	}
 	if len(objects) > 1 {
 		return Object{}, errors.New("too many objects matching template")


### PR DESCRIPTION
It looks like there was a simple omission of an error return in the `Session.FindObject` method of the `p11` module.