### PR TITLE
[p11] Split PublicKey and PrivateKey into separate files.

### DIFF
--- a/p11/private_key.go
+++ b/p11/private_key.go
@@ -1,0 +1,43 @@
+package p11
+
+import "github.com/miekg/pkcs11"
+
+// PrivateKey is an Object representing a private key. Since any object can be cast to a
+// PrivateKey, it is the user's responsibility to ensure that the object is
+// actually a private key.
+// For instance, if you use a FindObjects template that
+// includes CKA_CLASS: CKO_PRIVATE_KEY, you can be confident the resulting object
+// is a public key.
+type PrivateKey Object
+
+// Decrypt decrypts the input with a given mechanism.
+func (priv PrivateKey) Decrypt(mechanism pkcs11.Mechanism, ciphertext []byte) ([]byte, error) {
+	s := priv.session
+	s.Lock()
+	defer s.Unlock()
+	err := s.ctx.DecryptInit(s.handle, []*pkcs11.Mechanism{&mechanism}, priv.objectHandle)
+	if err != nil {
+		return nil, err
+	}
+	out, err := s.ctx.Decrypt(s.handle, ciphertext)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Sign signs the input with a given mechanism.
+func (priv PrivateKey) Sign(mechanism pkcs11.Mechanism, message []byte) ([]byte, error) {
+	s := priv.session
+	s.Lock()
+	defer s.Unlock()
+	err := s.ctx.SignInit(s.handle, []*pkcs11.Mechanism{&mechanism}, priv.objectHandle)
+	if err != nil {
+		return nil, err
+	}
+	out, err := s.ctx.Sign(s.handle, message)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/p11/public_key.go
+++ b/p11/public_key.go
@@ -9,43 +9,6 @@ import "github.com/miekg/pkcs11"
 // is a public key.
 type PublicKey Object
 
-// PrivateKey is an Object representing a private key. Since any object can be cast to a
-// PrivateKey, it is the user's responsibility to ensure that the object is
-// actually a private key.
-type PrivateKey Object
-
-// Decrypt decrypts the input with a given mechanism.
-func (priv PrivateKey) Decrypt(mechanism pkcs11.Mechanism, ciphertext []byte) ([]byte, error) {
-	s := priv.session
-	s.Lock()
-	defer s.Unlock()
-	err := s.ctx.DecryptInit(s.handle, []*pkcs11.Mechanism{&mechanism}, priv.objectHandle)
-	if err != nil {
-		return nil, err
-	}
-	out, err := s.ctx.Decrypt(s.handle, ciphertext)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-// Sign signs the input with a given mechanism.
-func (priv PrivateKey) Sign(mechanism pkcs11.Mechanism, message []byte) ([]byte, error) {
-	s := priv.session
-	s.Lock()
-	defer s.Unlock()
-	err := s.ctx.SignInit(s.handle, []*pkcs11.Mechanism{&mechanism}, priv.objectHandle)
-	if err != nil {
-		return nil, err
-	}
-	out, err := s.ctx.Sign(s.handle, message)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 // Verify verifies a signature over a message with a given mechanism.
 func (pub PublicKey) Verify(mechanism pkcs11.Mechanism, message, signature []byte) error {
 	s := pub.session


### PR DESCRIPTION
This split is in anticipation of adding a `SecretKey` type, corresponding to `CKO_SECRET_KEY`, which is thus far absent from the `p11` package.