### PR TITLE
Add typed convenience `Find...` methods to `Session`

### DIFF
--- a/p11/secret_key.go
+++ b/p11/secret_key.go
@@ -1,0 +1,42 @@
+package p11
+
+import "github.com/miekg/pkcs11"
+
+// SecretKey is an Object representing a secret (symmetric) key. Since any object can be cast to a
+// SecretKey, it is the user's responsibility to ensure that the object is
+// actually a secret key. For instance, if you use a FindObjects template that
+// includes CKA_CLASS: CKO_SECRET_KEY, you can be confident the resulting object
+// is a secret key.
+type SecretKey Object
+
+// Encrypt encrypts a plaintext with a given mechanism.
+func (secret SecretKey) Encrypt(mechanism pkcs11.Mechanism, plaintext []byte) ([]byte, error) {
+	s := secret.session
+	s.Lock()
+	defer s.Unlock()
+	err := s.ctx.EncryptInit(s.handle, []*pkcs11.Mechanism{&mechanism}, secret.objectHandle)
+	if err != nil {
+		return nil, err
+	}
+	out, err := s.ctx.Encrypt(s.handle, plaintext)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Decrypt decrypts the input with a given mechanism.
+func (secret SecretKey) Decrypt(mechanism pkcs11.Mechanism, ciphertext []byte) ([]byte, error) {
+	s := secret.session
+	s.Lock()
+	defer s.Unlock()
+	err := s.ctx.DecryptInit(s.handle, []*pkcs11.Mechanism{&mechanism}, secret.objectHandle)
+	if err != nil {
+		return nil, err
+	}
+	out, err := s.ctx.Decrypt(s.handle, ciphertext)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/p11/session.go
+++ b/p11/session.go
@@ -54,6 +54,37 @@ type sessionImpl struct {
 	handle pkcs11.SessionHandle
 }
 
+func (s *sessionImpl) FindPrivateKey(label string) (PrivateKey, error) {
+	obj, err := s.findObjectWithClassAndLabel(pkcs11.CKO_PRIVATE_KEY, label)
+	if err != nil {
+		return PrivateKey(obj), err
+	}
+	return PrivateKey(obj), nil
+}
+
+func (s *sessionImpl) FindPublicKey(label string) (PublicKey, error) {
+	obj, err := s.findObjectWithClassAndLabel(pkcs11.CKO_PUBLIC_KEY, label)
+	if err != nil {
+		return PublicKey(obj), err
+	}
+	return PublicKey(obj), nil
+}
+
+func (s *sessionImpl) FindSecretKey(label string) (SecretKey, error) {
+	obj, err := s.findObjectWithClassAndLabel(pkcs11.CKO_SECRET_KEY, label)
+	if err != nil {
+		return SecretKey(obj), err
+	}
+	return SecretKey(obj), nil
+}
+
+func (s *sessionImpl) findObjectWithClassAndLabel(class uint, label string) (Object, error) {
+	return s.FindObject([]*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, class),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
+	})
+}
+
 func (s *sessionImpl) FindObject(template []*pkcs11.Attribute) (Object, error) {
 	objects, err := s.FindObjects(template)
 	if err != nil {


### PR DESCRIPTION
This makes it a little easier to use a `Session` to find objects of the desired type, for the common case where you know the class and have the name as a parameter. It also provides an interface that's a little harder to mis-use.

[EDIT:] Builds on #99.