### PR TITLE
Do not use libtool for dynamic library management

### DIFF
--- a/pkcs11.go
+++ b/pkcs11.go
@@ -12,42 +12,72 @@ package pkcs11
 
 /*
 #cgo windows CFLAGS: -DPACKED_STRUCTURES
-#cgo windows LDFLAGS: -lltdl
-#cgo linux LDFLAGS: -lltdl -ldl
-#cgo darwin CFLAGS: -I/usr/local/share/libtool
-#cgo darwin LDFLAGS: -lltdl -L/usr/local/lib/
-#cgo openbsd CFLAGS: -I/usr/local/include/
-#cgo openbsd LDFLAGS: -lltdl -L/usr/local/lib/
-#cgo freebsd CFLAGS: -I/usr/local/include/
-#cgo freebsd LDFLAGS: -lltdl -L/usr/local/lib/
-#cgo LDFLAGS: -lltdl
+#cgo linux LDFLAGS: -ldl
+#cgo darwin LDFLAGS: -ldl
+#cgo openbsd LDFLAGS: -ldl
+#cgo freebsd LDFLAGS: -ldl
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <ltdl.h>
 #include <unistd.h>
+
 #include "pkcs11go.h"
 
+#ifdef _WIN32
+#include <windows.h>
+
 struct ctx {
-	lt_dlhandle handle;
+	HMODULE handle;
 	CK_FUNCTION_LIST_PTR sym;
 };
 
 // New initializes a ctx and fills the symbol table.
 struct ctx *New(const char *module)
 {
-	if (lt_dlinit() != 0) {
-		return NULL;
-	}
 	CK_C_GetFunctionList list;
 	struct ctx *c = calloc(1, sizeof(struct ctx));
-	c->handle = lt_dlopen(module);
+	c->handle = LoadLibrary(module);
 	if (c->handle == NULL) {
 		free(c);
 		return NULL;
 	}
-	list = (CK_C_GetFunctionList) lt_dlsym(c->handle, "C_GetFunctionList");
+	list = (CK_C_GetFunctionList) GetProcAddress(c->handle, "C_GetFunctionList");
+	if (list == NULL) {
+		free(c);
+		return NULL;
+	}
+	list(&c->sym);
+	return c;
+}
+
+// Destroy cleans up a ctx.
+void Destroy(struct ctx *c)
+{
+	if (!c) {
+		return;
+	}
+	free(c);
+}
+#else
+#include <dlfcn.h>
+
+struct ctx {
+	void *handle;
+	CK_FUNCTION_LIST_PTR sym;
+};
+
+// New initializes a ctx and fills the symbol table.
+struct ctx *New(const char *module)
+{
+	CK_C_GetFunctionList list;
+	struct ctx *c = calloc(1, sizeof(struct ctx));
+	c->handle = dlopen(module, RTLD_LAZY);
+	if (c->handle == NULL) {
+		free(c);
+		return NULL;
+	}
+	list = (CK_C_GetFunctionList) dlsym(c->handle, "C_GetFunctionList");
 	if (list == NULL) {
 		free(c);
 		return NULL;
@@ -65,12 +95,12 @@ void Destroy(struct ctx *c)
 	if (c->handle == NULL) {
 		return;
 	}
-	if (lt_dlclose(c->handle) < 0) {
+	if (dlclose(c->handle) < 0) {
 		return;
 	}
-	lt_dlexit();
 	free(c);
 }
+#endif
 
 CK_RV Initialize(struct ctx * c)
 {
@@ -751,11 +781,6 @@ type Ctx struct {
 
 // New creates a new context and initializes the module/library for use.
 func New(module string) *Ctx {
-	// libtool-ltdl will return an assertion error if passed an empty string, so
-	// we check for it explicitly.
-	if module == "" {
-		return nil
-	}
 	c := new(Ctx)
 	mod := C.CString(module)
 	defer C.free(unsafe.Pointer(mod))


### PR DESCRIPTION
libtool is licensed GPL unless your software is built with libtool, which rather conflicts with the fact that this library is otherwise BSD licensed.

Using `dlopen` on Unix and `LoadLibrary` on Windows is pretty simple as we are not doing anything complicated.

Tested on Linux, OSX and Windows.