### PR TITLE
Expose login API for vendor specific login types

### DIFF
--- a/p11/session.go
+++ b/p11/session.go
@@ -19,8 +19,10 @@ type Session interface {
 	// https://github.com/letsencrypt/pkcs11key/blob/master/key.go for an example
 	// of managing login state with a mutex.
 	Login(pin string) error
-	// Login logs into the token as the security officer.
+	// LoginSecurityOfficer logs into the token as the security officer.
 	LoginSecurityOfficer(pin string) error
+	// LoginAs logs into the token with the given user type.
+	LoginAs(userType uint, pin string) error
 	// Logout logs out all sessions from the token (see Login).
 	Logout() error
 	// Close closes the session.
@@ -105,14 +107,14 @@ func (s *sessionImpl) Close() error {
 }
 
 func (s *sessionImpl) Login(pin string) error {
-	return s.login(pkcs11.CKU_USER, pin)
+	return s.LoginAs(pkcs11.CKU_USER, pin)
 }
 
 func (s *sessionImpl) LoginSecurityOfficer(pin string) error {
-	return s.login(pkcs11.CKU_SO, pin)
+	return s.LoginAs(pkcs11.CKU_SO, pin)
 }
 
-func (s *sessionImpl) login(userType uint, pin string) error {
+func (s *sessionImpl) LoginAs(userType uint, pin string) error {
 	s.Lock()
 	defer s.Unlock()
 	return s.ctx.Login(s.handle, userType, pin)


### PR DESCRIPTION
First of all thx for the great library, it's really helped me a lot.

The purpose of this PR is to change a bit the session's login API in order to support custom (vendor specific) user types. 

I'm working ATM with SafeNet's Luna SA module and it has support for richer and stricter user model. In order to be able to use its user model one must provide user type in vendor range (above `0x80000000`), so in order to not pollute the library with vendor-specific detail best option seems to be exposition of login method.