### PR TITLE
Add CK_EFFECTIVELY_INFINITE and CK_UNAVAILABLE_INFORMATION

### DIFF
--- a/const.go
+++ b/const.go
@@ -723,3 +723,8 @@ const (
 	CKD_NULL                             = 0x00000001
 	CKD_SHA1_KDF                         = 0x00000002
 )
+
+const (
+	CK_EFFECTIVELY_INFINITE = 0
+	CK_UNAVAILABLE_INFORMATION = ^uint(0)
+)

--- a/const.go
+++ b/const.go
@@ -724,7 +724,13 @@ const (
 	CKD_SHA1_KDF                         = 0x00000002
 )
 
+// Special return values defined in PKCS#11 v2.40 section 3.2.
 const (
+	// CK_EFFECTIVELY_INFINITE may be returned in the CK_TOKEN_INFO fields ulMaxSessionCount and ulMaxRwSessionCount.
+	// It indicates there is no practical limit on the number of sessions.
 	CK_EFFECTIVELY_INFINITE = 0
+
+	// CK_UNAVAILABLE_INFORMATION may be returned for several fields within CK_TOKEN_INFO. It indicates
+	// the token is unable or unwilling to provide the requested information.
 	CK_UNAVAILABLE_INFORMATION = ^uint(0)
 )


### PR DESCRIPTION
Adds two constants, which are useful when looking at token capabilities.

I think `^uint(0)` is as close as we can get to `(~0UL)`, but comments welcome!