### PR TITLE
Add SessionInfo.State constants

### DIFF
--- a/const.go
+++ b/const.go
@@ -722,6 +722,11 @@ const (
 	CKF_USER_FRIENDLY_OTP                = 0x00000020
 	CKD_NULL                             = 0x00000001
 	CKD_SHA1_KDF                         = 0x00000002
+	CKS_RO_PUBLIC_SESSION                = 0x00000000
+	CKS_RO_USER_FUNCTIONS                = 0x00000001
+	CKS_RW_PUBLIC_SESSION                = 0x00000002
+	CKS_RW_USER_FUNCTIONS                = 0x00000003
+	CKS_RW_SO_FUNCTIONS                  = 0x00000004
 )
 
 // Special return values defined in PKCS#11 v2.40 section 3.2.


### PR DESCRIPTION
This is to add some missing constants from PKCS#11 specification.

While I was using GetSessionInfo function from PKCS#11, I noticed that constants for SesseionInfo.State field is missing. 

Constant names and values are defined in the following:
[Appendix B. Manifest constants](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html#_Toc416959757)

The meaning of the constants are defined in the following:
[2.6 Sessions](http://docs.oasis-open.org/pkcs11/pkcs11-ug/v2.40/cn02/pkcs11-ug-v2.40-cn02.html#_Toc406759989)
