### PR TITLE
Add p11.Module.Destroy()

### DIFF
--- a/p11/module.go
+++ b/p11/module.go
@@ -123,3 +123,8 @@ func (m Module) Slots() ([]Slot, error) {
 	}
 	return result, nil
 }
+
+// Destroy unloads the module/library.
+func (m Module) Destroy() {
+	m.ctx.Destroy()
+}


### PR DESCRIPTION
I added it because I sometimes wanted to ctx.Destroy() at p11.