### PR TITLE
-ldl not required on OpenBSD

### DIFF
--- a/pkcs11.go
+++ b/pkcs11.go
@@ -14,7 +14,7 @@ package pkcs11
 #cgo windows CFLAGS: -DPACKED_STRUCTURES
 #cgo linux LDFLAGS: -ldl
 #cgo darwin LDFLAGS: -ldl
-#cgo openbsd LDFLAGS: -ldl
+#cgo openbsd LDFLAGS: 
 #cgo freebsd LDFLAGS: -ldl
 
 #include <stdlib.h>


### PR DESCRIPTION
https://www.openbsd.org/faq/ports/guide.html#PortsPolicy

libdl functionality is in libc on OpenBSD, so remove -ldl