### PR TITLE
Remove unnecessary defer from toList() function.

### DIFF
--- a/types.go
+++ b/types.go
@@ -53,7 +53,7 @@ func toList(clist C.CK_ULONG_PTR, size C.CK_ULONG) []uint {
 	for i := 0; i < len(l); i++ {
 		l[i] = uint(C.Index(clist, C.CK_ULONG(i)))
 	}
-	defer C.free(unsafe.Pointer(clist))
+	C.free(unsafe.Pointer(clist))
 	return l
 }
 


### PR DESCRIPTION
Defer is more expensive than a direct call, and right before a `return` statement is has no effect on the logic.