### PR TITLE
Remove unnecessary memory copies by C.GoBytes() calls

### DIFF
--- a/params.go
+++ b/params.go
@@ -84,7 +84,7 @@ func cGCMParams(p *GCMParams) []byte {
 	p.Free()
 	p.arena = arena
 	p.params = &params
-	return C.GoBytes(unsafe.Pointer(&params), C.int(unsafe.Sizeof(params)))
+	return memBytes(unsafe.Pointer(&params), unsafe.Sizeof(params))
 }
 
 // IV returns a copy of the actual IV used for the operation.
@@ -121,7 +121,7 @@ func NewPSSParams(hashAlg, mgf, saltLength uint) []byte {
 		mgf:     C.CK_RSA_PKCS_MGF_TYPE(mgf),
 		sLen:    C.CK_ULONG(saltLength),
 	}
-	return C.GoBytes(unsafe.Pointer(&p), C.int(unsafe.Sizeof(p)))
+	return memBytes(unsafe.Pointer(&p), unsafe.Sizeof(p))
 }
 
 // OAEPParams can be passed to NewMechanism to implement CKM_RSA_PKCS_OAEP.
@@ -153,7 +153,7 @@ func cOAEPParams(p *OAEPParams, arena arena) ([]byte, arena) {
 		// field is unaligned on windows so this has to call into C
 		C.putOAEPParams(&params, buf, len)
 	}
-	return C.GoBytes(unsafe.Pointer(&params), C.int(unsafe.Sizeof(params))), arena
+	return memBytes(unsafe.Pointer(&params), unsafe.Sizeof(params)), arena
 }
 
 // ECDH1DeriveParams can be passed to NewMechanism to implement CK_ECDH1_DERIVE_PARAMS.
@@ -186,5 +186,5 @@ func cECDH1DeriveParams(p *ECDH1DeriveParams, arena arena) ([]byte, arena) {
 	publicKeyData, publicKeyDataLen := arena.Allocate(p.PublicKeyData)
 	C.putECDH1PublicParams(&params, publicKeyData, publicKeyDataLen)
 
-	return C.GoBytes(unsafe.Pointer(&params), C.int(unsafe.Sizeof(params))), arena
+	return memBytes(unsafe.Pointer(&params), unsafe.Sizeof(params)), arena
 }

--- a/types.go
+++ b/types.go
@@ -65,9 +65,15 @@ func cBBool(x bool) C.CK_BBOOL {
 	return C.CK_BBOOL(C.CK_FALSE)
 }
 
+// memBytes returns a byte slice that references an arbitrary memory area
+func memBytes(p unsafe.Pointer, len uintptr) []byte {
+	const maxIndex int32 = (1 << 31) - 1
+	return (*([maxIndex]byte))(p)[:len:len]
+}
+
 func uintToBytes(x uint64) []byte {
 	ul := C.CK_ULONG(x)
-	return C.GoBytes(unsafe.Pointer(&ul), C.int(unsafe.Sizeof(ul)))
+	return memBytes(unsafe.Pointer(&ul), unsafe.Sizeof(ul))
 }
 
 // Error represents an PKCS#11 error.


### PR DESCRIPTION
It is not necessary to copy the memory in order to get a []byte
representation of Go allocated memory, because the GC will take care
of the lifetime of the underlying memory.  This change introduces the
memBytes() function, that returns a slice to an arbitrary memory
area, and replaces all uses of C.GoBytes with Go allocated memory.
This function could even be used for C allocated memory, but then the
caller has to make sure that the underlying C memory is not freed
during the lifetime of the returned slice.

Signed-off-by: Sven Anderson <sven@anderson.de>