### PR TITLE
p11: Add Mechanism.Type() and Mechanism.Parameter()

### DIFF
--- a/p11/slot.go
+++ b/p11/slot.go
@@ -91,6 +91,16 @@ type Mechanism struct {
 	slot      Slot
 }
 
+// Type returns the type of mechanism.
+func (m *Mechanism) Type() uint {
+	return m.mechanism.Mechanism
+}
+
+// Parameter returns any parameters required by the mechanism.
+func (m *Mechanism) Parameter() []byte {
+	return m.mechanism.Parameter
+}
+
 // Info returns information about this mechanism.
 func (m *Mechanism) Info() (pkcs11.MechanismInfo, error) {
 	return m.slot.ctx.GetMechanismInfo(m.slot.id, []*pkcs11.Mechanism{m.mechanism})


### PR DESCRIPTION
I chose to add 2 methods instead of exporting the pkcs11.Mechanism because this way the calling code is less verbose, i.e. `mechanism.Type()` instead of `mechanism.Mechanism.Mechanism`.

Fixes https://github.com/miekg/pkcs11/issues/158