### PR TITLE
Call Finalize on Module destroy

### DIFF
--- a/p11/module.go
+++ b/p11/module.go
@@ -71,11 +71,11 @@ var modulesMu sync.Mutex
 // OpenModule loads a PKCS#11 module (a .so file or dynamically loaded library).
 // It's an error to load a PKCS#11 module multiple times, so this package
 // will return a previously loaded Module for the same path if possible.
-// Note that there is no facility to unload a module ("finalize" in PKCS#11
-// parlance). In general, modules will be unloaded at the end of the process.
-// The only place where you are likely to need to explicitly unload a module is
-// if you fork your process. If you need to fork, you may want to use the
-// lower-level `pkcs11` package.
+//
+// In general, modules will be unloaded at the end of the process. The only
+// place where you are likely to need to explicitly unload a module is if you
+// fork your process. If you need to fork, you may want to use the lower-level
+// `pkcs11` package.
 func OpenModule(path string) (Module, error) {
 	modulesMu.Lock()
 	defer modulesMu.Unlock()
@@ -125,6 +125,26 @@ func (m Module) Slots() ([]Slot, error) {
 }
 
 // Destroy unloads the module/library.
+//
+// Once called, any code which uses this module might crash the application.
 func (m Module) Destroy() error {
+	modulesMu.Lock()
+	defer modulesMu.Unlock()
+
+	// Find initialized module based on ctx
+	var path string
+	for k, v := range modules {
+		if v.ctx == m.ctx {
+			path = k
+			break
+		}
+	}
+	if path == "" {
+		return fmt.Errorf("failed to find initialized module")
+	}
+
+	err := m.ctx.Finalize()
 	m.ctx.Destroy()
+	delete(modules, path)
+	return err
 }

--- a/p11/module.go
+++ b/p11/module.go
@@ -125,6 +125,6 @@ func (m Module) Slots() ([]Slot, error) {
 }
 
 // Destroy unloads the module/library.
-func (m Module) Destroy() {
+func (m Module) Destroy() error {
 	m.ctx.Destroy()
 }

--- a/p11/module.go
+++ b/p11/module.go
@@ -127,7 +127,7 @@ func (m Module) Slots() ([]Slot, error) {
 // Destroy unloads the module/library.
 //
 // Once called, any code which uses this module might crash the application.
-func (m Module) Destroy() error {
+func (m Module) Destroy() {
 	modulesMu.Lock()
 	defer modulesMu.Unlock()
 
@@ -139,12 +139,10 @@ func (m Module) Destroy() error {
 			break
 		}
 	}
-	if path == "" {
-		return fmt.Errorf("failed to find initialized module")
+	if path != "" {
+		delete(modules, path)
 	}
 
-	err := m.ctx.Finalize()
+	_ = m.ctx.Finalize()
 	m.ctx.Destroy()
-	delete(modules, path)
-	return err
 }


### PR DESCRIPTION
While using softhsm in some tests, I ran into issues while re-using the same pkcs11 context. Calling `module.Destroy` together with these fixes allow me to use the p11 module (instead of going all in on the raw pkcs11 interface).

* Returns `error` from the `Module.Destroy` in p11. This is an API change. I can remove this if wanted.

* Calls `ctx.Finalize` before calling `ctx.Destroy` in `Module.Destroy`

This allow a more graceful unloading of modules. I suspect there are multiple reasons why you didn't do this before? At least removing the loaded module from the map should improve a lot.