### PR TITLE
Singular KeyDerivationStringDataParams

### DIFF
--- a/params.go
+++ b/params.go
@@ -26,6 +26,12 @@ static inline void putECDH1PublicParams(CK_ECDH1_DERIVE_PARAMS_PTR params, CK_VO
 	params->pPublicData = pPublicData;
 	params->ulPublicDataLen = ulPublicDataLen;
 }
+
+static inline void putKeyDerivationStringDataParams(CK_KEY_DERIVATION_STRING_DATA_PTR params, CK_BYTE_PTR pData, CK_ULONG ulLen)
+{
+	params->pData = pData;
+	params->ulLen = ulLen;
+}
 */
 import "C"
 import "unsafe"
@@ -185,6 +191,25 @@ func cECDH1DeriveParams(p *ECDH1DeriveParams, arena arena) ([]byte, arena) {
 
 	publicKeyData, publicKeyDataLen := arena.Allocate(p.PublicKeyData)
 	C.putECDH1PublicParams(&params, publicKeyData, publicKeyDataLen)
+
+	return memBytes(unsafe.Pointer(&params), unsafe.Sizeof(params)), arena
+}
+
+type KeyDerivationStringDataParams struct {
+	pData []byte
+}
+
+func NewKeyDerivationStringDataParams(data []byte) *KeyDerivationStringDataParams {
+	return &KeyDerivationStringDataParams{
+		pData: data,
+	}
+}
+
+func cKeyDerivationStringDataParams(p *KeyDerivationStringDataParams, arena arena) ([]byte, arena) {
+	params := C.CK_KEY_DERIVATION_STRING_DATA{}
+
+	pData, ulLen := arena.Allocate(p.pData)
+	C.putKeyDerivationStringDataParams(&params, C.CK_BYTE_PTR(pData), ulLen)
 
 	return memBytes(unsafe.Pointer(&params), unsafe.Sizeof(params)), arena
 }

--- a/types.go
+++ b/types.go
@@ -261,13 +261,13 @@ func NewMechanism(mech uint, x interface{}) *Mechanism {
 	}
 
 	switch p := x.(type) {
-	case *GCMParams, *OAEPParams, *ECDH1DeriveParams:
+	case *GCMParams, *OAEPParams, *ECDH1DeriveParams, *KeyDerivationStringDataParams:
 		// contains pointers; defer serialization until cMechanism
 		m.generator = p
 	case []byte:
 		m.Parameter = p
 	default:
-		panic("parameter must be one of type: []byte, *GCMParams, *OAEPParams, *ECDH1DeriveParams")
+		panic("parameter must be one of type: []byte, *GCMParams, *OAEPParams, *ECDH1DeriveParams, *KeyDerivationStringDataParams")
 	}
 
 	return m
@@ -290,6 +290,8 @@ func cMechanism(mechList []*Mechanism) (arena, *C.CK_MECHANISM) {
 		param, arena = cOAEPParams(p, arena)
 	case *ECDH1DeriveParams:
 		param, arena = cECDH1DeriveParams(p, arena)
+	case *KeyDerivationStringDataParams:
+		param, arena = cKeyDerivationStringDataParams(p, arena)
 	}
 	if len(param) != 0 {
 		buf, len := arena.Allocate(param)


### PR DESCRIPTION
Implement [PKCS #11 CK_KEY_DERIVATION_STRING_DATA](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cs01/pkcs11-curr-v2.40-cs01.html#_Toc399399057).

Unit tests cover AES Key Derivation

### Discussion

This PR ended up being a case of convergent evolution with https://github.com/miekg/pkcs11/pull/123 but the KeyDerivationStringDataParams but follows the current convention (and [uses putKeyDerivationStringDataParams()](https://github.com/miekg/pkcs11/compare/master...pdtgct:pkcs11:master?expand=1#diff-9e53fe9bf7266754a18a5710b5e83f44a905cce9a94dd4a042969020c7653992R212) where [PR 123 does not](https://github.com/miekg/pkcs11/pull/123/files#diff-9e53fe9bf7266754a18a5710b5e83f44a905cce9a94dd4a042969020c7653992R218-R219).

I would be happy to revise this PR and merge changes with https://github.com/miekg/pkcs11/pull/123 but that has not been merged yet.

