### PR TITLE
Add RSA AES key wrap mechanism parameters

### DIFF
--- a/params.go
+++ b/params.go
@@ -26,6 +26,11 @@ static inline void putECDH1PublicParams(CK_ECDH1_DERIVE_PARAMS_PTR params, CK_VO
 	params->pPublicData = pPublicData;
 	params->ulPublicDataLen = ulPublicDataLen;
 }
+
+static inline void putRSAAESKeyWrapParams(CK_RSA_AES_KEY_WRAP_PARAMS_PTR params, CK_VOID_PTR pOAEPParams)
+{
+	params->pOAEPParams = pOAEPParams;
+}
 */
 import "C"
 import "unsafe"
@@ -188,3 +193,23 @@ func cECDH1DeriveParams(p *ECDH1DeriveParams, arena arena) ([]byte, arena) {
 
 	return memBytes(unsafe.Pointer(&params), unsafe.Sizeof(params)), arena
 }
+
+type RSAAESKeyWrapParams struct {
+	AESKeyBits uint
+	OAEPParams OAEPParams
+}
+
+func cRSAAESKeyWrapParams(p *RSAAESKeyWrapParams, arena arena) ([]byte, arena) {
+	var param []byte
+	params := C.CK_RSA_AES_KEY_WRAP_PARAMS {
+		ulAESKeyBits: C.CK_MECHANISM_TYPE(p.AESKeyBits),
+	}
+
+	param, arena = cOAEPParams(&p.OAEPParams, arena)
+	if len(param) != 0 {
+		buf, _ := arena.Allocate(param)
+		C.putRSAAESKeyWrapParams(&params, buf)
+	}
+	return memBytes(unsafe.Pointer(&params), unsafe.Sizeof(params)), arena
+}
+

--- a/types.go
+++ b/types.go
@@ -261,13 +261,14 @@ func NewMechanism(mech uint, x interface{}) *Mechanism {
 	}
 
 	switch p := x.(type) {
-	case *GCMParams, *OAEPParams, *ECDH1DeriveParams:
+	case *GCMParams, *OAEPParams, *ECDH1DeriveParams, *RSAAESKeyWrapParams:
 		// contains pointers; defer serialization until cMechanism
 		m.generator = p
 	case []byte:
 		m.Parameter = p
 	default:
-		panic("parameter must be one of type: []byte, *GCMParams, *OAEPParams, *ECDH1DeriveParams")
+		panic("parameter must be one of type: []byte, *GCMParams, *OAEPParams, *ECDH1DeriveParams," +
+			  " *RSAAESKeyWrapParams")
 	}
 
 	return m
@@ -290,6 +291,8 @@ func cMechanism(mechList []*Mechanism) (arena, *C.CK_MECHANISM) {
 		param, arena = cOAEPParams(p, arena)
 	case *ECDH1DeriveParams:
 		param, arena = cECDH1DeriveParams(p, arena)
+	case *RSAAESKeyWrapParams:
+		param, arena = cRSAAESKeyWrapParams(p, arena)
 	}
 	if len(param) != 0 {
 		buf, len := arena.Allocate(param)


### PR DESCRIPTION
Mechanism implementation:
https://github.com/OP-TEE/optee_os/pull/5647

pkcs11-spec-v3.1-cs01
6.1.23 RSA AES KEY WRAP

The RSA AES key wrap mechanism based on the RSA public-key cryptosystem and the AES key wrap mechanism. It supports single-part key wrapping and key unwrapping.

How to use:
```
params := &pkcs11.RSAAESKeyWrapParams{
	AESKeyBits: 256,
	OAEPParams: pkcs11.OAEPParams{
		HashAlg:    pkcs11.CKM_SHA256,
		MGF:        pkcs11.CKG_MGF1_SHA256,
		SourceType: pkcs11.CKZ_DATA_SPECIFIED,
	},
}
mechanism := []*pkcs11.Mechanism {
    pkcs11.NewMechanism(pkcs11.CKM_RSA_AES_KEY_WRAP, params)
}
unwrappedKey, err := ctx.UnwrapKey(session, mechanism, wrappingKeyObj,
                                   wrappedKey, unwrappedKeyAttributes)
```
