### PR TITLE
const_generate: hardcode CK_TRUE/CK_FALSE to golang bool values

### DIFF
--- a/const_generate.go
+++ b/const_generate.go
@@ -70,15 +70,23 @@ func main() {
 			prevpre = x
 		}
 
-		value := strings.TrimSuffix(fields[2], "UL")
-		// special case for things like: (CKF_ARRAY_ATTRIBUTE|0x00000211UL)
-		if strings.HasSuffix(value, "UL)") {
-			value = strings.Replace(value, "UL)", ")", 1)
-		}
-		// CK_UNAVAILABLE_INFORMATION is encoded as (~0) (with UL) removed, this needs to be ^uint(0) in Go.
-		// Special case that here.
-		if value == "(~0)" {
-			value = "^uint(0)"
+		var value string
+		switch fields[1] {
+		case "CK_TRUE":
+			value = "true"
+		case "CK_FALSE":
+			value = "false"
+		default:
+			value = strings.TrimSuffix(fields[2], "UL")
+			// special case for things like: (CKF_ARRAY_ATTRIBUTE|0x00000211UL)
+			if strings.HasSuffix(value, "UL)") {
+				value = strings.Replace(value, "UL)", ")", 1)
+			}
+			// CK_UNAVAILABLE_INFORMATION is encoded as (~0) (with UL) removed, this needs to be ^uint(0) in Go.
+			// Special case that here.
+			if value == "(~0)" {
+				value = "^uint(0)"
+			}
 		}
 
 		if comment != "" {

--- a/zconst.go
+++ b/zconst.go
@@ -7,8 +7,8 @@
 package pkcs11
 
 const (
-	CK_TRUE  = 1
-	CK_FALSE = 0
+	CK_TRUE  = true
+	CK_FALSE = false
 
 	// some special values for certain CK_ULONG variables
 	CK_UNAVAILABLE_INFORMATION = ^uint(0)
@@ -22,13 +22,15 @@ const (
 	CKN_OTP_CHANGED = 1
 
 	// flags: bit flags that provide capabilities of the slot
-	//      Bit Flag              Mask        Meaning
+	//
+	//	Bit Flag              Mask        Meaning
 	CKF_TOKEN_PRESENT    = 0x00000001 // a token is there
 	CKF_REMOVABLE_DEVICE = 0x00000002 // removable devices
 	CKF_HW_SLOT          = 0x00000004 // hardware slot
 
 	// The flags parameter is defined as follows:
-	//      Bit Flag                    Mask        Meaning
+	//
+	//	Bit Flag                    Mask        Meaning
 	CKF_RNG                  = 0x00000001 // has random # generator
 	CKF_WRITE_PROTECTED      = 0x00000002 // token is write-protected
 	CKF_LOGIN_REQUIRED       = 0x00000004 // user must login
@@ -125,7 +127,8 @@ const (
 	CKS_RW_SO_FUNCTIONS   = 4
 
 	// The flags are defined in the following table:
-	//      Bit Flag                Mask        Meaning
+	//
+	//	Bit Flag                Mask        Meaning
 	CKF_RW_SESSION     = 0x00000002 // session is r/w
 	CKF_SERIAL_SESSION = 0x00000004 // no parallel
 
@@ -710,7 +713,8 @@ const (
 	CKM_VENDOR_DEFINED                 = 0x80000000
 
 	// The flags are defined as follows:
-	//      Bit Flag               Mask          Meaning
+	//
+	//	Bit Flag               Mask          Meaning
 	CKF_HW = 0x00000001 // performed by HW
 
 	// Specify whether or not a mechanism can be used for a particular task
@@ -834,7 +838,8 @@ const (
 	CKR_VENDOR_DEFINED                   = 0x80000000
 
 	// flags: bit flags that provide capabilities of the slot
-	//      Bit Flag                           Mask       Meaning
+	//
+	//	Bit Flag                           Mask       Meaning
 	CKF_LIBRARY_CANT_CREATE_OS_THREADS = 0x00000001
 	CKF_OS_LOCKING_OK                  = 0x00000002
 


### PR DESCRIPTION
The PKCS11 constants are most useful when creating attributes with
`NewAttribute()` in all kinds of different PKCS11 calls. The function
is using generic type handling to decide attribute length.

The CK_TRUE/CK_FALSE constants should evaluate to direct Golang
bool values in order for these to be handled properly by the
`NewAttribute()` calls, which interprets bool values as
[]byte{0}, []byte{1} for false, true respectively. If these stay
integers, `NewAttribtue()` considers them 8-byte long byte slices.

Some PKCS11 module implementations actually validate constant-length
arguments size. https://github.com/opendnssec/SoftHSMv2/ is an example
of a commonly used PKCS11-testing module that does that. Without this
change, the module fails to perform certain actions as it errors out
on unexpected attribute size.