### PR TITLE
memBytes: avoid hardcoded max size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/miekg/pkcs11
 
-go 1.12
+go 1.17

--- a/types.go
+++ b/types.go
@@ -67,8 +67,7 @@ func cBBool(x bool) C.CK_BBOOL {
 
 // memBytes returns a byte slice that references an arbitrary memory area
 func memBytes(p unsafe.Pointer, len uintptr) []byte {
-	const maxIndex int32 = (1 << 31) - 1
-	return (*([maxIndex]byte))(p)[:len:len]
+	return unsafe.Slice((*byte)(p), len)
 }
 
 func uintToBytes(x uint64) []byte {


### PR DESCRIPTION
memBytes: avoid hardcoded max size and instead use `unsafe.Slice`.

I'm building a tool for a tiny MIPS32, but my compiler complains about:
> types.go:69:6: type [2147483647]byte larger than address space
